### PR TITLE
Properly apply extraArgs to JavaExec

### DIFF
--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
@@ -186,9 +186,7 @@ class SculptorVersion : Plugin<Project> {
                             args("--nogui")
                         }
 
-                        extraArgs.map {
-                            args(it)
-                        }
+                        args(extraArgs.getOrElse(emptyList()))
 
                         workingDir.mkdirs()
                     }
@@ -255,9 +253,7 @@ class SculptorVersion : Plugin<Project> {
                                 args("--assetIndex", assetsInfo!!.assetIndex)
                             }
 
-                            extraArgs.map {
-                                args(it)
-                            }
+                            args(extraArgs.getOrElse(emptyList()))
 
                             workingDir(runClientDirectory)
 


### PR DESCRIPTION
Correctly call #get on the extraArgs ListProperty to resolve its content instead of calling Provider#map on it, which simply creates a transforming provider based on extraArgs without actually evaluating the transformation logic until queried.