### PR TITLE
update jgit dependency to 7.0.0

### DIFF
--- a/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
@@ -39,12 +39,6 @@ repositories {
             includeGroupAndSubgroups("net.covers1624")
         }
     }
-    maven("https://repo.eclipse.org/content/groups/releases/") {
-        name = "Eclipse"
-        mavenContent {
-            includeGroupAndSubgroups("org.eclipse")
-        }
-    }
     mavenCentral()
 }
 

--- a/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/config-kotlin.gradle.kts
@@ -39,6 +39,12 @@ repositories {
             includeGroupAndSubgroups("net.covers1624")
         }
     }
+    maven("https://repo.eclipse.org/content/groups/releases/") {
+        name = "Eclipse"
+        mavenContent {
+            includeGroupAndSubgroups("org.eclipse")
+        }
+    }
     mavenCentral()
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ serialize-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", 
 serialize-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialize" }
 diffpatch = "codechicken:DiffPatch:1.5.0.30"
 coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2"
-jgit = "org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r"
+jgit = "org.eclipse.jgit:org.eclipse.jgit:7.0.0.202407311305-m2"
 
 xml-core = { module = "io.github.pdvrieze.xmlutil:core-jvm", version.ref = "xml" }
 xml-serialize = { module = "io.github.pdvrieze.xmlutil:serialization-jvm", version.ref = "xml" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ serialize-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", 
 serialize-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialize" }
 diffpatch = "codechicken:DiffPatch:1.5.0.30"
 coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2"
-jgit = "org.eclipse.jgit:org.eclipse.jgit:7.0.0.202407311305-m2"
+jgit = "org.eclipse.jgit:org.eclipse.jgit:7.0.0.202409031743-r"
 
 xml-core = { module = "io.github.pdvrieze.xmlutil:core-jvm", version.ref = "xml" }
 xml-serialize = { module = "io.github.pdvrieze.xmlutil:serialization-jvm", version.ref = "xml" }


### PR DESCRIPTION
fixes #11 

Note: Only releases are pushed to Maven Central, so we need to reference the eclipse repo to access the milestone build. 

If we want to avoid referencing the eclipse repo then I can just update this PR to use the release build when it comes out (which will probably be a month from now)