### PR TITLE
Include Client Patches

### DIFF
--- a/sculptor-shared/src/main/kotlin/io/papermc/sculptor/shared/util/ArtifactVersionProvider.kt
+++ b/sculptor-shared/src/main/kotlin/io/papermc/sculptor/shared/util/ArtifactVersionProvider.kt
@@ -10,11 +10,12 @@ abstract class ArtifactVersionProvider : ValueSource<String, ArtifactVersionProv
     interface BuildIdParameters : ValueSourceParameters {
         val repoUrl: Property<String>
         val mcVersion: Property<String>
+        val jarType: Property<MinecraftJarType>
         val ci: Property<String>
     }
 
     override fun obtain(): String {
-        return parameters.mcVersion.get() + "+build." + buildVersion()
+        return "${parameters.mcVersion.get()}-${parameters.jarType.getOrElse(MinecraftJarType.SERVER)}+build.${buildVersion()}"
     }
 
     private fun buildVersion(): String {

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
@@ -271,6 +271,7 @@ class SculptorVersion : Plugin<Project> {
             parameters {
                 repoUrl.set(REPO_URL)
                 mcVersion.set(mache.minecraftVersion)
+                jarType.set(mache.minecraftJarType)
                 ci.set(target.providers.environmentVariable("CI").orElse("false"))
             }
         }


### PR DESCRIPTION
This approach changes the names of the `versions/$ver` directory to have a `-server` and `-client` directory respectively. 

Then it modifies the migrate task to migrate both server and client directories to the new version. 

The `createMacheArtifact` task has also been updated to distinguish between client and server. 
