### PR TITLE
Publish minecraft dependencies as variants

### DIFF
--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/ConfigureVersionProject.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/ConfigureVersionProject.kt
@@ -73,13 +73,20 @@ object ConfigureVersionProject {
 
             dependencies {
                 for (library in libraries) {
-                    "minecraft"(library)
+                    "minecraft"(library) {
+                        isTransitive = false
+                    }
+                    "serverDependencies"(library) {
+                        isTransitive = false
+                    }
                 }
             }
         } else {
             dependencies {
                 for (library in mcVersionManifest.libraries) {
-                    "minecraft"(library.name)
+                    "minecraft"(library.name) {
+                        isTransitive = false
+                    }
                 }
             }
         }

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/MacheOutput.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/MacheOutput.kt
@@ -1,0 +1,16 @@
+package io.papermc.sculptor.version
+
+import org.gradle.api.Named
+import org.gradle.api.attributes.Attribute
+
+interface MacheOutput : Named {
+    companion object {
+        val ATTRIBUTE = Attribute.of(
+            "io.papermc.mache.output",
+            MacheOutput::class.java
+        )
+
+        const val ZIP = "zip"
+        const val SERVER_DEPENDENCIES = "serverDependencies"
+    }
+}


### PR DESCRIPTION
```json
{
  "formatVersion": "1.1",
  "component": {
    "group": "io.papermc",
    "module": "mache",
    "version": "1.21.4+build.local-SNAPSHOT",
    "attributes": {
      "org.gradle.status": "integration"
    }
  },
  "createdBy": {
    "gradle": {
      "version": "8.11"
    }
  },
  "variants": [
    {
      "name": "macheZip",
      "attributes": {
        "io.papermc.mache.output": "zip"
      },
      "files": [
        {
          "name": "mache-1.21.4+build.local-SNAPSHOT.zip",
          "url": "mache-1.21.4+build.local-SNAPSHOT.zip",
          "size": 46418,
          "sha512": "c0aa1616f78b145216f88eb6858462ae4df5b323638dfba4c5ad06ad5fe2373a26cdf8797c825f14857b780c2a5bb01f5de380a5da54dfd82a59a5ac675ce25b",
          "sha256": "1454a5609b1f76adb7e07c50ba40c43b86c1f3c254aa41c41997a2a8b7d48969",
          "sha1": "49a1d0de9f28214ecd6480912106f44a54670ce4",
          "md5": "37035311b516499176b793993b9af694"
        }
      ]
    },
    {
      "name": "serverCompileDependencies",
      "attributes": {
        "io.papermc.mache.output": "serverDependencies",
        "org.gradle.usage": "java-api"
      },
      "dependencies": [
        {
          "group": "com.fasterxml.jackson.core",
          "module": "jackson-annotations",
          "version": {
            "requires": "2.13.4"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.fasterxml.jackson.core",
          "module": "jackson-core",
          "version": {
            "requires": "2.13.4"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.fasterxml.jackson.core",
          "module": "jackson-databind",
          "version": {
            "requires": "2.13.4.2"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.github.oshi",
          "module": "oshi-core",
          "version": {
            "requires": "6.6.5"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.github.stephenc.jcip",
          "module": "jcip-annotations",
          "version": {
            "requires": "1.0-1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.google.code.gson",
          "module": "gson",
          "version": {
            "requires": "2.11.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.google.guava",
          "module": "failureaccess",
          "version": {
            "requires": "1.0.2"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.google.guava",
          "module": "guava",
          "version": {
            "requires": "33.3.1-jre"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.microsoft.azure",
          "module": "msal4j",
          "version": {
            "requires": "1.17.2"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "authlib",
          "version": {
            "requires": "6.0.57"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "brigadier",
          "version": {
            "requires": "1.3.10"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "datafixerupper",
          "version": {
            "requires": "8.0.16"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "jtracy",
          "version": {
            "requires": "1.0.29"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "logging",
          "version": {
            "requires": "1.5.10"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "content-type",
          "version": {
            "requires": "2.3"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "lang-tag",
          "version": {
            "requires": "1.7"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "nimbus-jose-jwt",
          "version": {
            "requires": "9.40"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "oauth2-oidc-sdk",
          "version": {
            "requires": "11.18"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "commons-io",
          "module": "commons-io",
          "version": {
            "requires": "2.17.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-buffer",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-codec",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-common",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-handler",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-resolver",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-transport",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-transport-classes-epoll",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-transport-native-epoll",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ],
          "thirdPartyCompatibility": {
            "artifactSelector": {
              "name": "netty-transport-native-epoll",
              "type": "jar",
              "extension": "jar",
              "classifier": "linux-x86_64"
            }
          }
        },
        {
          "group": "io.netty",
          "module": "netty-transport-native-epoll",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ],
          "thirdPartyCompatibility": {
            "artifactSelector": {
              "name": "netty-transport-native-epoll",
              "type": "jar",
              "extension": "jar",
              "classifier": "linux-aarch_64"
            }
          }
        },
        {
          "group": "io.netty",
          "module": "netty-transport-native-unix-common",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "it.unimi.dsi",
          "module": "fastutil",
          "version": {
            "requires": "8.5.15"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.java.dev.jna",
          "module": "jna",
          "version": {
            "requires": "5.15.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.java.dev.jna",
          "module": "jna-platform",
          "version": {
            "requires": "5.15.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.minidev",
          "module": "accessors-smart",
          "version": {
            "requires": "2.5.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.minidev",
          "module": "json-smart",
          "version": {
            "requires": "2.5.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.sf.jopt-simple",
          "module": "jopt-simple",
          "version": {
            "requires": "5.0.4"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.commons",
          "module": "commons-lang3",
          "version": {
            "requires": "3.17.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.logging.log4j",
          "module": "log4j-api",
          "version": {
            "requires": "2.24.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.logging.log4j",
          "module": "log4j-core",
          "version": {
            "requires": "2.24.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.logging.log4j",
          "module": "log4j-slf4j2-impl",
          "version": {
            "requires": "2.24.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.joml",
          "module": "joml",
          "version": {
            "requires": "1.10.8"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.lz4",
          "module": "lz4-java",
          "version": {
            "requires": "1.8.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.ow2.asm",
          "module": "asm",
          "version": {
            "requires": "9.6"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.slf4j",
          "module": "slf4j-api",
          "version": {
            "requires": "2.0.16"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        }
      ]
    },
    {
      "name": "serverRuntimeDependencies",
      "attributes": {
        "io.papermc.mache.output": "serverDependencies",
        "org.gradle.usage": "java-runtime"
      },
      "dependencies": [
        {
          "group": "com.fasterxml.jackson.core",
          "module": "jackson-annotations",
          "version": {
            "requires": "2.13.4"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.fasterxml.jackson.core",
          "module": "jackson-core",
          "version": {
            "requires": "2.13.4"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.fasterxml.jackson.core",
          "module": "jackson-databind",
          "version": {
            "requires": "2.13.4.2"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.github.oshi",
          "module": "oshi-core",
          "version": {
            "requires": "6.6.5"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.github.stephenc.jcip",
          "module": "jcip-annotations",
          "version": {
            "requires": "1.0-1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.google.code.gson",
          "module": "gson",
          "version": {
            "requires": "2.11.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.google.guava",
          "module": "failureaccess",
          "version": {
            "requires": "1.0.2"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.google.guava",
          "module": "guava",
          "version": {
            "requires": "33.3.1-jre"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.microsoft.azure",
          "module": "msal4j",
          "version": {
            "requires": "1.17.2"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "authlib",
          "version": {
            "requires": "6.0.57"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "brigadier",
          "version": {
            "requires": "1.3.10"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "datafixerupper",
          "version": {
            "requires": "8.0.16"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "jtracy",
          "version": {
            "requires": "1.0.29"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.mojang",
          "module": "logging",
          "version": {
            "requires": "1.5.10"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "content-type",
          "version": {
            "requires": "2.3"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "lang-tag",
          "version": {
            "requires": "1.7"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "nimbus-jose-jwt",
          "version": {
            "requires": "9.40"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "com.nimbusds",
          "module": "oauth2-oidc-sdk",
          "version": {
            "requires": "11.18"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "commons-io",
          "module": "commons-io",
          "version": {
            "requires": "2.17.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-buffer",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-codec",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-common",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-handler",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-resolver",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-transport",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-transport-classes-epoll",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "io.netty",
          "module": "netty-transport-native-epoll",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ],
          "thirdPartyCompatibility": {
            "artifactSelector": {
              "name": "netty-transport-native-epoll",
              "type": "jar",
              "extension": "jar",
              "classifier": "linux-x86_64"
            }
          }
        },
        {
          "group": "io.netty",
          "module": "netty-transport-native-epoll",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ],
          "thirdPartyCompatibility": {
            "artifactSelector": {
              "name": "netty-transport-native-epoll",
              "type": "jar",
              "extension": "jar",
              "classifier": "linux-aarch_64"
            }
          }
        },
        {
          "group": "io.netty",
          "module": "netty-transport-native-unix-common",
          "version": {
            "requires": "4.1.115.Final"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "it.unimi.dsi",
          "module": "fastutil",
          "version": {
            "requires": "8.5.15"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.java.dev.jna",
          "module": "jna",
          "version": {
            "requires": "5.15.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.java.dev.jna",
          "module": "jna-platform",
          "version": {
            "requires": "5.15.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.minidev",
          "module": "accessors-smart",
          "version": {
            "requires": "2.5.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.minidev",
          "module": "json-smart",
          "version": {
            "requires": "2.5.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "net.sf.jopt-simple",
          "module": "jopt-simple",
          "version": {
            "requires": "5.0.4"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.commons",
          "module": "commons-lang3",
          "version": {
            "requires": "3.17.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.logging.log4j",
          "module": "log4j-api",
          "version": {
            "requires": "2.24.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.logging.log4j",
          "module": "log4j-core",
          "version": {
            "requires": "2.24.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.apache.logging.log4j",
          "module": "log4j-slf4j2-impl",
          "version": {
            "requires": "2.24.1"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.joml",
          "module": "joml",
          "version": {
            "requires": "1.10.8"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.lz4",
          "module": "lz4-java",
          "version": {
            "requires": "1.8.0"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.ow2.asm",
          "module": "asm",
          "version": {
            "requires": "9.6"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        },
        {
          "group": "org.slf4j",
          "module": "slf4j-api",
          "version": {
            "requires": "2.0.16"
          },
          "excludes": [
            {
              "group": "*",
              "module": "*"
            }
          ]
        }
      ]
    }
  ]
}

```