### PR TITLE
Allow property based configuration of jvm heap

### DIFF
--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
@@ -89,7 +89,6 @@ abstract class SculptorVersion : Plugin<Project> {
 
             outputJar.set(layout.buildDirectory.file(REMAPPED_JAR))
             reportsDir.set(layout.buildDirectory.dir(REPORTS_DIR))
-            (target.findProperty("io.papermc.sculptor.remapperHeap") as? String).let { memory.set(it) }
         }
 
         val decompileJar by target.tasks.registering(DecompileJar::class) {
@@ -100,7 +99,6 @@ abstract class SculptorVersion : Plugin<Project> {
             this.decompiler.from(decompiler)
 
             outputJar.set(target.layout.buildDirectory.file(DECOMP_JAR))
-            (target.findProperty("io.papermc.sculptor.decompilerHeap") as? String).let { memory.set(it) }
         }
 
         val applyPatches by target.tasks.registering(ApplyPatches::class) {

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/SculptorVersion.kt
@@ -89,6 +89,7 @@ abstract class SculptorVersion : Plugin<Project> {
 
             outputJar.set(layout.buildDirectory.file(REMAPPED_JAR))
             reportsDir.set(layout.buildDirectory.dir(REPORTS_DIR))
+            (target.findProperty("io.papermc.sculptor.remapperHeap") as? String).let { memory.set(it) }
         }
 
         val decompileJar by target.tasks.registering(DecompileJar::class) {
@@ -99,6 +100,7 @@ abstract class SculptorVersion : Plugin<Project> {
             this.decompiler.from(decompiler)
 
             outputJar.set(target.layout.buildDirectory.file(DECOMP_JAR))
+            (target.findProperty("io.papermc.sculptor.decompilerHeap") as? String).let { memory.set(it) }
         }
 
         val applyPatches by target.tasks.registering(ApplyPatches::class) {

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/DecompileJar.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/DecompileJar.kt
@@ -15,6 +15,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
@@ -51,6 +52,13 @@ abstract class DecompileJar : DefaultTask() {
     @get:Inject
     abstract val layout: ProjectLayout
 
+    @get:Input
+    abstract val memory: Property<String>
+
+    init {
+        memory.convention("4G")
+    }
+
     @TaskAction
     fun run() {
         val out = outputJar.convertToPath().ensureClean()
@@ -72,7 +80,7 @@ abstract class DecompileJar : DefaultTask() {
                 classpath(decompiler)
                 mainClass.set("org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler")
 
-                maxHeapSize = (project.findProperty("io.papermc.sculptor.decompilerHeap") ?: "4G") as String
+                maxHeapSize = memory.get()
 
                 args(decompilerArgs.get())
                 args("-cfg", cfgFile.absolutePathString())

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/DecompileJar.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/DecompileJar.kt
@@ -72,7 +72,7 @@ abstract class DecompileJar : DefaultTask() {
                 classpath(decompiler)
                 mainClass.set("org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler")
 
-                maxHeapSize = "3G"
+                maxHeapSize = (project.findProperty("io.papermc.sculptor.decompilerHeap") ?: "3G") as String
 
                 args(decompilerArgs.get())
                 args("-cfg", cfgFile.absolutePathString())

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/DecompileJar.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/DecompileJar.kt
@@ -72,7 +72,7 @@ abstract class DecompileJar : DefaultTask() {
                 classpath(decompiler)
                 mainClass.set("org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler")
 
-                maxHeapSize = (project.findProperty("io.papermc.sculptor.decompilerHeap") ?: "3G") as String
+                maxHeapSize = (project.findProperty("io.papermc.sculptor.decompilerHeap") ?: "4G") as String
 
                 args(decompilerArgs.get())
                 args("-cfg", cfgFile.absolutePathString())

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/RemapJar.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/RemapJar.kt
@@ -8,6 +8,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.process.ExecOperations
 import javax.inject.Inject
@@ -57,6 +58,13 @@ abstract class RemapJar : DefaultTask() {
     @get:Inject
     abstract val layout: ProjectLayout
 
+    @get:Input
+    abstract val memory: Property<String>
+
+    init {
+        memory.convention("2G")
+    }
+
     @TaskAction
     fun run() {
         val out = outputJar.convertToPath().ensureClean()
@@ -67,7 +75,7 @@ abstract class RemapJar : DefaultTask() {
             exec.javaexec {
                 classpath(codebookClasspath.singleFile)
 
-                maxHeapSize = (project.findProperty("io.papermc.sculptor.remapperHeap") ?: "2G") as String
+                maxHeapSize = memory.get()
 
                 remapperArgs.get().forEach { arg ->
                     args(arg

--- a/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/RemapJar.kt
+++ b/sculptor-version/src/main/kotlin/io/papermc/sculptor/version/tasks/RemapJar.kt
@@ -67,7 +67,7 @@ abstract class RemapJar : DefaultTask() {
             exec.javaexec {
                 classpath(codebookClasspath.singleFile)
 
-                maxHeapSize = "2G"
+                maxHeapSize = (project.findProperty("io.papermc.sculptor.remapperHeap") ?: "2G") as String
 
                 remapperArgs.get().forEach { arg ->
                     args(arg


### PR DESCRIPTION
Sculptor spawns two child jvms during its workflow, specifically
remapping and decompilation. Both of these have been limited to a
hardcoded maximum heap which *might* be too low in some cases.

The commit allows users to configure their own value for these heap
limitations via gradle properties.
